### PR TITLE
For procedure, now using DateTime instead of String

### DIFF
--- a/FhirDeathRecord.CLI/1.json
+++ b/FhirDeathRecord.CLI/1.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "id": "urn:uuid:3c8a7735-34d0-4ec4-a31d-941961ab8013",
+  "id": "urn:uuid:63eaa04b-f60e-461f-a8bb-b8c558eb2a7b",
   "meta": {
     "profile": [
       "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document"
@@ -12,10 +12,10 @@
   "type": "document",
   "entry": [
     {
-      "fullUrl": "urn:uuid:f54d60d0-8846-4f99-9e52-bf0e5bf0a881",
+      "fullUrl": "urn:uuid:d2fcdfbd-3494-42b4-a140-2827a24a47ae",
       "resource": {
         "resourceType": "Composition",
-        "id": "urn:uuid:f54d60d0-8846-4f99-9e52-bf0e5bf0a881",
+        "id": "urn:uuid:d2fcdfbd-3494-42b4-a140-2827a24a47ae",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate"
@@ -35,7 +35,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "date": "2019-01-20T16:47:04.498822-05:00",
         "attester": [
@@ -45,7 +45,7 @@
             ],
             "time": "2019-01-29T16:48:06.498822-05:00",
             "party": {
-              "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+              "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
             }
           }
         ],
@@ -64,7 +64,7 @@
             ],
             "detail": [
               {
-                "reference": "urn:uuid:d78430ea-36ac-4a00-9cb4-eb177c10613f"
+                "reference": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04"
               }
             ]
           }
@@ -73,100 +73,100 @@
           {
             "entry": [
               {
-                "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+                "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
               },
               {
-                "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+                "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
               },
               {
-                "reference": "urn:uuid:1a7877f4-988c-47f6-9ad9-e6e65f67dde2"
+                "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
               },
               {
-                "reference": "urn:uuid:d78430ea-36ac-4a00-9cb4-eb177c10613f"
+                "reference": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04"
               },
               {
-                "reference": "urn:uuid:2746f741-41ec-4358-9f79-538e5ef6731a"
+                "reference": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244"
               },
               {
-                "reference": "urn:uuid:56ca40d2-412e-410d-bef2-e0ed0263e6d5"
+                "reference": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313"
               },
               {
-                "reference": "urn:uuid:6d8dbf2f-df1d-458d-ad8f-016a71c916c3"
+                "reference": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295"
               },
               {
-                "reference": "urn:uuid:43296ff0-9208-4f76-93a9-91f4f2292ce5"
+                "reference": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6"
               },
               {
-                "reference": "urn:uuid:9bf3b560-d659-45f4-8a09-505ad0ec20df"
+                "reference": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b"
               },
               {
-                "reference": "urn:uuid:a2de17f6-0281-48e5-8b5d-b9fd6e7ba07e"
+                "reference": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109"
               },
               {
-                "reference": "urn:uuid:872c52a4-0064-4360-87f5-5cf33da5686e"
+                "reference": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547"
               },
               {
-                "reference": "urn:uuid:9e818d52-f227-43e4-8adc-7b4bfd27e7f0"
+                "reference": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2"
               },
               {
-                "reference": "urn:uuid:c08de6a4-b033-4a20-a816-65de0f0f1690"
+                "reference": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a"
               },
               {
-                "reference": "urn:uuid:1f853753-5f87-49d0-ba76-70b069d1b791"
+                "reference": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29"
               },
               {
-                "reference": "urn:uuid:819bdaf8-783f-421e-8b3e-47475af18e4e"
+                "reference": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65"
               },
               {
-                "reference": "urn:uuid:9c055c8c-2d2f-4746-82af-20177d708fd1"
+                "reference": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc"
               },
               {
-                "reference": "urn:uuid:2f3a5f58-6bad-4f3b-b9d3-89936cdbe104"
+                "reference": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820"
               },
               {
-                "reference": "urn:uuid:e7dab674-4334-452a-89d3-5bd76bbd52a7"
+                "reference": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4"
               },
               {
-                "reference": "urn:uuid:c5b7153d-f903-4ecd-b5fe-451c5aa2a58d"
+                "reference": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932"
               },
               {
-                "reference": "urn:uuid:207a0fa5-3845-4878-8995-1cf39fabb596"
+                "reference": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201"
               },
               {
-                "reference": "urn:uuid:6ea1b997-c60e-446c-9469-600a5f124d47"
+                "reference": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e"
               },
               {
-                "reference": "urn:uuid:5bdf1669-9f59-4fc5-9ea7-56c919d73d4e"
+                "reference": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749"
               },
               {
-                "reference": "urn:uuid:5456e711-6847-4b85-bb5a-aad70c9c5735"
+                "reference": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895"
               },
               {
-                "reference": "urn:uuid:771c6b64-b017-4f19-b1d3-80e51ec70a31"
+                "reference": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35"
               },
               {
-                "reference": "urn:uuid:54a057f0-a4c9-4257-89a4-0eafff07cec5"
+                "reference": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d"
               },
               {
-                "reference": "urn:uuid:5c49f5b0-1b01-4b37-9c9f-5f4d4224a8d6"
+                "reference": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20"
               },
               {
-                "reference": "urn:uuid:de388294-7d63-4e9f-9a27-08ef5342cee1"
+                "reference": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1"
               },
               {
-                "reference": "urn:uuid:cfead8cb-5125-4dba-8fe0-6a45434a8e50"
+                "reference": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2"
               },
               {
-                "reference": "urn:uuid:610a1a5d-b4f9-4a26-92c4-da58767b65de"
+                "reference": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69"
               },
               {
-                "reference": "urn:uuid:3926a1a5-e41e-4a22-99ab-3639740c931d"
+                "reference": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436"
               },
               {
-                "reference": "urn:uuid:d1586aec-9f21-4a21-b369-8f3bcd1e8c55"
+                "reference": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c"
               },
               {
-                "reference": "urn:uuid:618cf470-fc32-4bd4-8a7c-72f55c51a865"
+                "reference": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed"
               }
             ]
           }
@@ -174,10 +174,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca",
+      "fullUrl": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8",
       "resource": {
         "resourceType": "Patient",
-        "id": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca",
+        "id": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent"
@@ -324,10 +324,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141",
+      "fullUrl": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141",
+        "id": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier"
@@ -375,10 +375,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:1a7877f4-988c-47f6-9ad9-e6e65f67dde2",
+      "fullUrl": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "urn:uuid:1a7877f4-988c-47f6-9ad9-e6e65f67dde2",
+        "id": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician"
@@ -409,10 +409,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:d78430ea-36ac-4a00-9cb4-eb177c10613f",
+      "fullUrl": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04",
       "resource": {
         "resourceType": "Procedure",
-        "id": "urn:uuid:d78430ea-36ac-4a00-9cb4-eb177c10613f",
+        "id": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification"
@@ -437,7 +437,7 @@
             }
           ]
         },
-        "performedString": "2019-01-29T16:48:06.498822-05:00",
+        "performedDateTime": "2019-01-29T16:48:06.498822-05:00",
         "performer": [
           {
             "role": {
@@ -450,17 +450,17 @@
               ]
             },
             "actor": {
-              "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+              "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl": "urn:uuid:2746f741-41ec-4358-9f79-538e5ef6731a",
+      "fullUrl": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244",
       "resource": {
         "resourceType": "Organization",
-        "id": "urn:uuid:2746f741-41ec-4358-9f79-538e5ef6731a",
+        "id": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party"
@@ -500,10 +500,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:56ca40d2-412e-410d-bef2-e0ed0263e6d5",
+      "fullUrl": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313",
       "resource": {
         "resourceType": "Organization",
-        "id": "urn:uuid:56ca40d2-412e-410d-bef2-e0ed0263e6d5",
+        "id": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
@@ -536,28 +536,28 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:6d8dbf2f-df1d-458d-ad8f-016a71c916c3",
+      "fullUrl": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295",
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "urn:uuid:6d8dbf2f-df1d-458d-ad8f-016a71c916c3",
+        "id": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home-Director"
           ]
         },
         "practitioner": {
-          "reference": "urn:uuid:1a7877f4-988c-47f6-9ad9-e6e65f67dde2"
+          "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
         },
         "organization": {
-          "reference": "urn:uuid:56ca40d2-412e-410d-bef2-e0ed0263e6d5"
+          "reference": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:43296ff0-9208-4f76-93a9-91f4f2292ce5",
+      "fullUrl": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6",
       "resource": {
         "resourceType": "List",
-        "id": "urn:uuid:43296ff0-9208-4f76-93a9-91f4f2292ce5",
+        "id": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway"
@@ -566,7 +566,7 @@
         "status": "current",
         "mode": "snapshot",
         "source": {
-          "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         },
         "orderedBy": {
           "coding": [
@@ -578,32 +578,32 @@
         "entry": [
           {
             "item": {
-              "reference": "urn:uuid:9e818d52-f227-43e4-8adc-7b4bfd27e7f0"
+              "reference": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:c08de6a4-b033-4a20-a816-65de0f0f1690"
+              "reference": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:1f853753-5f87-49d0-ba76-70b069d1b791"
+              "reference": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:819bdaf8-783f-421e-8b3e-47475af18e4e"
+              "reference": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65"
             }
           }
         ]
       }
     },
     {
-      "fullUrl": "urn:uuid:9bf3b560-d659-45f4-8a09-505ad0ec20df",
+      "fullUrl": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:9bf3b560-d659-45f4-8a09-505ad0ec20df",
+        "id": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
@@ -624,10 +624,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:a2de17f6-0281-48e5-8b5d-b9fd6e7ba07e",
+      "fullUrl": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:a2de17f6-0281-48e5-8b5d-b9fd6e7ba07e",
+        "id": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death"
@@ -644,11 +644,11 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "performer": [
           {
-            "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+            "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
           }
         ],
         "valueCodeableConcept": {
@@ -662,10 +662,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:872c52a4-0064-4360-87f5-5cf33da5686e",
+      "fullUrl": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:872c52a4-0064-4360-87f5-5cf33da5686e",
+        "id": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
@@ -675,15 +675,15 @@
           "text": "Example Contributing Conditions"
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:9e818d52-f227-43e4-8adc-7b4bfd27e7f0",
+      "fullUrl": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:9e818d52-f227-43e4-8adc-7b4bfd27e7f0",
+        "id": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -700,19 +700,19 @@
           "text": "Rupture of myocardium"
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "minutes",
         "asserter": {
-          "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:c08de6a4-b033-4a20-a816-65de0f0f1690",
+      "fullUrl": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:c08de6a4-b033-4a20-a816-65de0f0f1690",
+        "id": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -729,19 +729,19 @@
           "text": "Acute myocardial infarction"
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "6 days",
         "asserter": {
-          "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:1f853753-5f87-49d0-ba76-70b069d1b791",
+      "fullUrl": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:1f853753-5f87-49d0-ba76-70b069d1b791",
+        "id": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -751,19 +751,19 @@
           "text": "Coronary artery thrombosis"
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "5 years",
         "asserter": {
-          "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:819bdaf8-783f-421e-8b3e-47475af18e4e",
+      "fullUrl": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:819bdaf8-783f-421e-8b3e-47475af18e4e",
+        "id": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -773,26 +773,26 @@
           "text": "Atherosclerotic coronary artery disease"
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "7 years",
         "asserter": {
-          "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:9c055c8c-2d2f-4746-82af-20177d708fd1",
+      "fullUrl": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:9c055c8c-2d2f-4746-82af-20177d708fd1",
+        "id": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -816,17 +816,17 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:2f3a5f58-6bad-4f3b-b9d3-89936cdbe104",
+      "fullUrl": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:2f3a5f58-6bad-4f3b-b9d3-89936cdbe104",
+        "id": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -850,17 +850,17 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:e7dab674-4334-452a-89d3-5bd76bbd52a7",
+      "fullUrl": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:e7dab674-4334-452a-89d3-5bd76bbd52a7",
+        "id": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -884,10 +884,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:c5b7153d-f903-4ecd-b5fe-451c5aa2a58d",
+      "fullUrl": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:c5b7153d-f903-4ecd-b5fe-451c5aa2a58d",
+        "id": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level"
@@ -904,7 +904,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -918,10 +918,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:207a0fa5-3845-4878-8995-1cf39fabb596",
+      "fullUrl": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:207a0fa5-3845-4878-8995-1cf39fabb596",
+        "id": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Birth-Record-Identifier"
@@ -936,16 +936,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueString": "4242123"
       }
     },
     {
-      "fullUrl": "urn:uuid:6ea1b997-c60e-446c-9469-600a5f124d47",
+      "fullUrl": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:6ea1b997-c60e-446c-9469-600a5f124d47",
+        "id": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Employment-History"
@@ -962,7 +962,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "component": [
           {
@@ -1029,10 +1029,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:5bdf1669-9f59-4fc5-9ea7-56c919d73d4e",
+      "fullUrl": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:5bdf1669-9f59-4fc5-9ea7-56c919d73d4e",
+        "id": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method"
@@ -1042,7 +1042,7 @@
           {
             "url": "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location",
             "valueReference": {
-              "reference": "urn:uuid:9bf3b560-d659-45f4-8a09-505ad0ec20df"
+              "reference": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b"
             }
           }
         ],
@@ -1057,11 +1057,11 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "performer": [
           {
-            "reference": "urn:uuid:1a7877f4-988c-47f6-9ad9-e6e65f67dde2"
+            "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
           }
         ],
         "valueCodeableConcept": {
@@ -1076,10 +1076,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:5456e711-6847-4b85-bb5a-aad70c9c5735",
+      "fullUrl": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:5456e711-6847-4b85-bb5a-aad70c9c5735",
+        "id": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator"
@@ -1096,7 +1096,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1132,10 +1132,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:771c6b64-b017-4f19-b1d3-80e51ec70a31",
+      "fullUrl": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:771c6b64-b017-4f19-b1d3-80e51ec70a31",
+        "id": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age"
@@ -1152,7 +1152,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueQuantity": {
           "value": 100,
@@ -1161,10 +1161,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:54a057f0-a4c9-4257-89a4-0eafff07cec5",
+      "fullUrl": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:54a057f0-a4c9-4257-89a4-0eafff07cec5",
+        "id": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy"
@@ -1181,7 +1181,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1195,10 +1195,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:5c49f5b0-1b01-4b37-9c9f-5f4d4224a8d6",
+      "fullUrl": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:5c49f5b0-1b01-4b37-9c9f-5f4d4224a8d6",
+        "id": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
@@ -1215,7 +1215,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1229,10 +1229,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:de388294-7d63-4e9f-9a27-08ef5342cee1",
+      "fullUrl": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:de388294-7d63-4e9f-9a27-08ef5342cee1",
+        "id": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted"
@@ -1249,16 +1249,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueBoolean": false
       }
     },
     {
-      "fullUrl": "urn:uuid:cfead8cb-5125-4dba-8fe0-6a45434a8e50",
+      "fullUrl": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:cfead8cb-5125-4dba-8fe0-6a45434a8e50",
+        "id": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death"
@@ -1275,7 +1275,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1289,10 +1289,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:610a1a5d-b4f9-4a26-92c4-da58767b65de",
+      "fullUrl": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:610a1a5d-b4f9-4a26-92c4-da58767b65de",
+        "id": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
@@ -1314,10 +1314,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:3926a1a5-e41e-4a22-99ab-3639740c931d",
+      "fullUrl": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:3926a1a5-e41e-4a22-99ab-3639740c931d",
+        "id": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Incident"
@@ -1334,16 +1334,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "effectiveDateTime": "2018-02-19T16:48:06.498822-05:00"
       }
     },
     {
-      "fullUrl": "urn:uuid:d1586aec-9f21-4a21-b369-8f3bcd1e8c55",
+      "fullUrl": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:d1586aec-9f21-4a21-b369-8f3bcd1e8c55",
+        "id": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
@@ -1365,10 +1365,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:618cf470-fc32-4bd4-8a7c-72f55c51a865",
+      "fullUrl": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:618cf470-fc32-4bd4-8a7c-72f55c51a865",
+        "id": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date"
@@ -1385,12 +1385,12 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:c1721070-a78d-4abd-974a-b083ca9f35ca"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "effectiveDateTime": "2018-02-19T16:48:06.498822-05:00",
         "performer": [
           {
-            "reference": "urn:uuid:fb60ae20-0074-4edf-83c0-0732ff6ef141"
+            "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
           }
         ],
         "component": [

--- a/FhirDeathRecord.CLI/1.xml
+++ b/FhirDeathRecord.CLI/1.xml
@@ -1,5 +1,5 @@
 <Bundle xmlns="http://hl7.org/fhir">
-  <id value="urn:uuid:5ca0dc37-c6ae-4896-a497-0863c92c089e" />
+  <id value="urn:uuid:1f85404c-19bf-413e-b975-d87f1a48ab08" />
   <meta>
     <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document" />
   </meta>
@@ -8,10 +8,10 @@
   </identifier>
   <type value="document" />
   <entry>
-    <fullUrl value="urn:uuid:e35bc503-0851-470a-8403-71ca32410557" />
+    <fullUrl value="urn:uuid:792f37f0-9a17-4016-9a51-ca6899d5bc1d" />
     <resource>
       <Composition>
-        <id value="urn:uuid:e35bc503-0851-470a-8403-71ca32410557" />
+        <id value="urn:uuid:792f37f0-9a17-4016-9a51-ca6899d5bc1d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate" />
         </meta>
@@ -27,14 +27,14 @@
           </coding>
         </type>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <date value="2019-01-20T16:47:04.4988220-05:00" />
         <attester>
           <mode value="legal" />
           <time value="2019-01-29T16:48:06.4988220-05:00" />
           <party>
-            <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </party>
         </attester>
         <event>
@@ -46,115 +46,115 @@
             </coding>
           </code>
           <detail>
-            <reference value="urn:uuid:18695de5-03a4-4f1a-a2ee-b4940f41b5a3" />
+            <reference value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
           </detail>
         </event>
         <section>
           <entry>
-            <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+            <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
           </entry>
           <entry>
-            <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </entry>
           <entry>
-            <reference value="urn:uuid:52e757b8-d084-41f7-af5e-c8dbc0aafe52" />
+            <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:18695de5-03a4-4f1a-a2ee-b4940f41b5a3" />
+            <reference value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
           </entry>
           <entry>
-            <reference value="urn:uuid:7d7cb38a-7108-4d58-a2c4-8149f70457a9" />
+            <reference value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
           </entry>
           <entry>
-            <reference value="urn:uuid:2b2c215b-19bc-445d-b043-663220ffd0a0" />
+            <reference value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
           </entry>
           <entry>
-            <reference value="urn:uuid:3f99cf03-ea80-457a-9cf2-ad2866e7aa42" />
+            <reference value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
           </entry>
           <entry>
-            <reference value="urn:uuid:cdbfcca5-903a-40cc-abdc-d93241b6ddb1" />
+            <reference value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
           </entry>
           <entry>
-            <reference value="urn:uuid:c2063322-7438-43e0-aa4d-482130e6a7bb" />
+            <reference value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
           </entry>
           <entry>
-            <reference value="urn:uuid:a296d8fb-d93b-4874-bee8-7d8b76402240" />
+            <reference value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
           </entry>
           <entry>
-            <reference value="urn:uuid:07a18360-58af-43b2-87a9-fb5d40a2963b" />
+            <reference value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
           </entry>
           <entry>
-            <reference value="urn:uuid:6aa96ef9-2ee7-4dae-aed8-91c3f70ab2e2" />
+            <reference value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
           </entry>
           <entry>
-            <reference value="urn:uuid:816ad043-1d10-465a-8b8c-6e98206dc810" />
+            <reference value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
           </entry>
           <entry>
-            <reference value="urn:uuid:479d13dc-e386-4999-a5dc-18ddf530f2d8" />
+            <reference value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
           </entry>
           <entry>
-            <reference value="urn:uuid:a1d4c254-9b20-46fa-8b0b-c75a84dceba9" />
+            <reference value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
           </entry>
           <entry>
-            <reference value="urn:uuid:043cf042-83b8-4a49-8361-08890da93b2e" />
+            <reference value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
           </entry>
           <entry>
-            <reference value="urn:uuid:4f8cde98-c60c-4887-b824-b9b76ecffe6d" />
+            <reference value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
           </entry>
           <entry>
-            <reference value="urn:uuid:b115ff9b-2c5f-4506-b82a-97b1ee58d4fa" />
+            <reference value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
           </entry>
           <entry>
-            <reference value="urn:uuid:e99b5724-6af4-42a6-b04e-47eefad5b32e" />
+            <reference value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
           </entry>
           <entry>
-            <reference value="urn:uuid:f363d0be-11d0-4420-93ad-dd55af1ed6c3" />
+            <reference value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:8625b496-2f44-4129-ab38-6e5535245b26" />
+            <reference value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
           </entry>
           <entry>
-            <reference value="urn:uuid:659136b0-ba76-4fad-822b-2ee15726a770" />
+            <reference value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
           </entry>
           <entry>
-            <reference value="urn:uuid:242247a3-eb83-423a-b7c9-8798767cdf6c" />
+            <reference value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
           </entry>
           <entry>
-            <reference value="urn:uuid:cee50519-54be-4c82-ab63-47666b2eb1b1" />
+            <reference value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:ff5ef7f7-27ee-4c32-b223-78b89412637f" />
+            <reference value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
           </entry>
           <entry>
-            <reference value="urn:uuid:1b62f1f6-59de-428d-b405-67acd5a81291" />
+            <reference value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
           </entry>
           <entry>
-            <reference value="urn:uuid:759b033d-9021-465b-afa7-f26baa9c31c3" />
+            <reference value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
           </entry>
           <entry>
-            <reference value="urn:uuid:9f3e3124-3e87-4a27-9b10-fba331549ca4" />
+            <reference value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
           </entry>
           <entry>
-            <reference value="urn:uuid:7fe8e8e7-28b5-4ec1-9062-0b3a4594b5ac" />
+            <reference value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
           </entry>
           <entry>
-            <reference value="urn:uuid:5dfbfbc2-c6da-4c31-ac04-000e49522a37" />
+            <reference value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:f753f4e1-68ca-474b-baf7-9697f30cb558" />
+            <reference value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
           </entry>
           <entry>
-            <reference value="urn:uuid:5f5efca1-d8ac-4846-bc3c-bb918ca05dc6" />
+            <reference value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
           </entry>
         </section>
       </Composition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+    <fullUrl value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
     <resource>
       <Patient>
-        <id value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+        <id value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent" />
         </meta>
@@ -262,10 +262,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+    <fullUrl value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
     <resource>
       <Practitioner>
-        <id value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+        <id value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier" />
         </meta>
@@ -298,10 +298,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:52e757b8-d084-41f7-af5e-c8dbc0aafe52" />
+    <fullUrl value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
     <resource>
       <Practitioner>
-        <id value="urn:uuid:52e757b8-d084-41f7-af5e-c8dbc0aafe52" />
+        <id value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician" />
         </meta>
@@ -321,10 +321,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:18695de5-03a4-4f1a-a2ee-b4940f41b5a3" />
+    <fullUrl value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
     <resource>
       <Procedure>
-        <id value="urn:uuid:18695de5-03a4-4f1a-a2ee-b4940f41b5a3" />
+        <id value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification" />
         </meta>
@@ -343,7 +343,7 @@
             <display value="Death certification" />
           </coding>
         </code>
-        <performedString value="2019-01-29T16:48:06.4988220-05:00" />
+        <performedDateTime value="2019-01-29T16:48:06.4988220-05:00" />
         <performer>
           <role>
             <coding>
@@ -353,17 +353,17 @@
             </coding>
           </role>
           <actor>
-            <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </actor>
         </performer>
       </Procedure>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:7d7cb38a-7108-4d58-a2c4-8149f70457a9" />
+    <fullUrl value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
     <resource>
       <Organization>
-        <id value="urn:uuid:7d7cb38a-7108-4d58-a2c4-8149f70457a9" />
+        <id value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" />
         </meta>
@@ -392,10 +392,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:2b2c215b-19bc-445d-b043-663220ffd0a0" />
+    <fullUrl value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
     <resource>
       <Organization>
-        <id value="urn:uuid:2b2c215b-19bc-445d-b043-663220ffd0a0" />
+        <id value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" />
         </meta>
@@ -419,34 +419,34 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:3f99cf03-ea80-457a-9cf2-ad2866e7aa42" />
+    <fullUrl value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
     <resource>
       <PractitionerRole>
-        <id value="urn:uuid:3f99cf03-ea80-457a-9cf2-ad2866e7aa42" />
+        <id value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home-Director" />
         </meta>
         <practitioner>
-          <reference value="urn:uuid:52e757b8-d084-41f7-af5e-c8dbc0aafe52" />
+          <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         </practitioner>
         <organization>
-          <reference value="urn:uuid:2b2c215b-19bc-445d-b043-663220ffd0a0" />
+          <reference value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
         </organization>
       </PractitionerRole>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:cdbfcca5-903a-40cc-abdc-d93241b6ddb1" />
+    <fullUrl value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
     <resource>
       <List>
-        <id value="urn:uuid:cdbfcca5-903a-40cc-abdc-d93241b6ddb1" />
+        <id value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway" />
         </meta>
         <status value="current" />
         <mode value="snapshot" />
         <source>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </source>
         <orderedBy>
           <coding>
@@ -455,32 +455,32 @@
         </orderedBy>
         <entry>
           <item>
-            <reference value="urn:uuid:6aa96ef9-2ee7-4dae-aed8-91c3f70ab2e2" />
+            <reference value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:816ad043-1d10-465a-8b8c-6e98206dc810" />
+            <reference value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:479d13dc-e386-4999-a5dc-18ddf530f2d8" />
+            <reference value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:a1d4c254-9b20-46fa-8b0b-c75a84dceba9" />
+            <reference value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
           </item>
         </entry>
       </List>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:c2063322-7438-43e0-aa4d-482130e6a7bb" />
+    <fullUrl value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
     <resource>
       <Location>
-        <id value="urn:uuid:c2063322-7438-43e0-aa4d-482130e6a7bb" />
+        <id value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" />
         </meta>
@@ -498,10 +498,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:a296d8fb-d93b-4874-bee8-7d8b76402240" />
+    <fullUrl value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
     <resource>
       <Observation>
-        <id value="urn:uuid:a296d8fb-d93b-4874-bee8-7d8b76402240" />
+        <id value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death" />
         </meta>
@@ -514,10 +514,10 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <performer>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </performer>
         <valueCodeableConcept>
           <coding>
@@ -529,10 +529,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:07a18360-58af-43b2-87a9-fb5d40a2963b" />
+    <fullUrl value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
     <resource>
       <Condition>
-        <id value="urn:uuid:07a18360-58af-43b2-87a9-fb5d40a2963b" />
+        <id value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" />
         </meta>
@@ -540,16 +540,16 @@
           <text value="Example Contributing Conditions" />
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:6aa96ef9-2ee7-4dae-aed8-91c3f70ab2e2" />
+    <fullUrl value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
     <resource>
       <Condition>
-        <id value="urn:uuid:6aa96ef9-2ee7-4dae-aed8-91c3f70ab2e2" />
+        <id value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -562,20 +562,20 @@
           <text value="Rupture of myocardium" />
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="minutes" />
         <asserter>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:816ad043-1d10-465a-8b8c-6e98206dc810" />
+    <fullUrl value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
     <resource>
       <Condition>
-        <id value="urn:uuid:816ad043-1d10-465a-8b8c-6e98206dc810" />
+        <id value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -588,20 +588,20 @@
           <text value="Acute myocardial infarction" />
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="6 days" />
         <asserter>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:479d13dc-e386-4999-a5dc-18ddf530f2d8" />
+    <fullUrl value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
     <resource>
       <Condition>
-        <id value="urn:uuid:479d13dc-e386-4999-a5dc-18ddf530f2d8" />
+        <id value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -609,20 +609,20 @@
           <text value="Coronary artery thrombosis" />
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="5 years" />
         <asserter>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:a1d4c254-9b20-46fa-8b0b-c75a84dceba9" />
+    <fullUrl value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
     <resource>
       <Condition>
-        <id value="urn:uuid:a1d4c254-9b20-46fa-8b0b-c75a84dceba9" />
+        <id value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -630,25 +630,25 @@
           <text value="Atherosclerotic coronary artery disease" />
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="7 years" />
         <asserter>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:043cf042-83b8-4a49-8361-08890da93b2e" />
+    <fullUrl value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:043cf042-83b8-4a49-8361-08890da93b2e" />
+        <id value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father" />
         </meta>
         <patient>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -665,15 +665,15 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:4f8cde98-c60c-4887-b824-b9b76ecffe6d" />
+    <fullUrl value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:4f8cde98-c60c-4887-b824-b9b76ecffe6d" />
+        <id value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother" />
         </meta>
         <patient>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -690,15 +690,15 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:b115ff9b-2c5f-4506-b82a-97b1ee58d4fa" />
+    <fullUrl value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:b115ff9b-2c5f-4506-b82a-97b1ee58d4fa" />
+        <id value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse" />
         </meta>
         <patient>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -715,10 +715,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:e99b5724-6af4-42a6-b04e-47eefad5b32e" />
+    <fullUrl value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
     <resource>
       <Observation>
-        <id value="urn:uuid:e99b5724-6af4-42a6-b04e-47eefad5b32e" />
+        <id value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level" />
         </meta>
@@ -731,7 +731,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -744,10 +744,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:f363d0be-11d0-4420-93ad-dd55af1ed6c3" />
+    <fullUrl value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:f363d0be-11d0-4420-93ad-dd55af1ed6c3" />
+        <id value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Birth-Record-Identifier" />
         </meta>
@@ -758,17 +758,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueString value="4242123" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:8625b496-2f44-4129-ab38-6e5535245b26" />
+    <fullUrl value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
     <resource>
       <Observation>
-        <id value="urn:uuid:8625b496-2f44-4129-ab38-6e5535245b26" />
+        <id value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Employment-History" />
         </meta>
@@ -781,7 +781,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <component>
           <code>
@@ -835,16 +835,16 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:659136b0-ba76-4fad-822b-2ee15726a770" />
+    <fullUrl value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
     <resource>
       <Observation>
-        <id value="urn:uuid:659136b0-ba76-4fad-822b-2ee15726a770" />
+        <id value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method" />
         </meta>
         <extension url="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location">
           <valueReference>
-            <reference value="urn:uuid:c2063322-7438-43e0-aa4d-482130e6a7bb" />
+            <reference value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
           </valueReference>
         </extension>
         <status value="final" />
@@ -856,10 +856,10 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <performer>
-          <reference value="urn:uuid:52e757b8-d084-41f7-af5e-c8dbc0aafe52" />
+          <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         </performer>
         <valueCodeableConcept>
           <coding>
@@ -872,10 +872,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:242247a3-eb83-423a-b7c9-8798767cdf6c" />
+    <fullUrl value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
     <resource>
       <Observation>
-        <id value="urn:uuid:242247a3-eb83-423a-b7c9-8798767cdf6c" />
+        <id value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator" />
         </meta>
@@ -888,7 +888,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -917,10 +917,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:cee50519-54be-4c82-ab63-47666b2eb1b1" />
+    <fullUrl value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:cee50519-54be-4c82-ab63-47666b2eb1b1" />
+        <id value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age" />
         </meta>
@@ -933,7 +933,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueQuantity>
           <value value="100" />
@@ -943,10 +943,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:ff5ef7f7-27ee-4c32-b223-78b89412637f" />
+    <fullUrl value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
     <resource>
       <Observation>
-        <id value="urn:uuid:ff5ef7f7-27ee-4c32-b223-78b89412637f" />
+        <id value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy" />
         </meta>
@@ -959,7 +959,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -972,10 +972,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:1b62f1f6-59de-428d-b405-67acd5a81291" />
+    <fullUrl value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
     <resource>
       <Observation>
-        <id value="urn:uuid:1b62f1f6-59de-428d-b405-67acd5a81291" />
+        <id value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role" />
         </meta>
@@ -988,7 +988,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -1001,10 +1001,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:759b033d-9021-465b-afa7-f26baa9c31c3" />
+    <fullUrl value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
     <resource>
       <Observation>
-        <id value="urn:uuid:759b033d-9021-465b-afa7-f26baa9c31c3" />
+        <id value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted" />
         </meta>
@@ -1017,17 +1017,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueBoolean value="false" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:9f3e3124-3e87-4a27-9b10-fba331549ca4" />
+    <fullUrl value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
     <resource>
       <Observation>
-        <id value="urn:uuid:9f3e3124-3e87-4a27-9b10-fba331549ca4" />
+        <id value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death" />
         </meta>
@@ -1040,7 +1040,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -1053,10 +1053,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:7fe8e8e7-28b5-4ec1-9062-0b3a4594b5ac" />
+    <fullUrl value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
     <resource>
       <Location>
-        <id value="urn:uuid:7fe8e8e7-28b5-4ec1-9062-0b3a4594b5ac" />
+        <id value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location" />
         </meta>
@@ -1075,10 +1075,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:5dfbfbc2-c6da-4c31-ac04-000e49522a37" />
+    <fullUrl value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:5dfbfbc2-c6da-4c31-ac04-000e49522a37" />
+        <id value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Incident" />
         </meta>
@@ -1091,17 +1091,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <effectiveDateTime value="2018-02-19T16:48:06.4988220-05:00" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:f753f4e1-68ca-474b-baf7-9697f30cb558" />
+    <fullUrl value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
     <resource>
       <Location>
-        <id value="urn:uuid:f753f4e1-68ca-474b-baf7-9697f30cb558" />
+        <id value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
         </meta>
@@ -1120,10 +1120,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:5f5efca1-d8ac-4846-bc3c-bb918ca05dc6" />
+    <fullUrl value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
     <resource>
       <Observation>
-        <id value="urn:uuid:5f5efca1-d8ac-4846-bc3c-bb918ca05dc6" />
+        <id value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date" />
         </meta>
@@ -1136,11 +1136,11 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:65ee7d6c-6b33-4862-8f9a-0c82acf53841" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <effectiveDateTime value="2018-02-19T16:48:06.4988220-05:00" />
         <performer>
-          <reference value="urn:uuid:19197ab0-863b-4107-87aa-90f2d6dc3807" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </performer>
         <component>
           <code>

--- a/FhirDeathRecord.CLI/Program.cs
+++ b/FhirDeathRecord.CLI/Program.cs
@@ -398,8 +398,8 @@ namespace FhirDeathRecord.CLI
                 // DateOfDeathPronouncement
                 deathRecord.DateOfDeathPronouncement = "2018-02-20T16:48:06.4988220-05:00";
 
-                //Console.WriteLine(XDocument.Parse(deathRecord.ToXML()).ToString() + "\n\n");
-                Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(Newtonsoft.Json.JsonConvert.DeserializeObject(deathRecord.ToJSON()), Newtonsoft.Json.Formatting.Indented) + "\n\n");
+                Console.WriteLine(XDocument.Parse(deathRecord.ToXML()).ToString() + "\n\n");
+                //Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(Newtonsoft.Json.JsonConvert.DeserializeObject(deathRecord.ToJSON()), Newtonsoft.Json.Formatting.Indented) + "\n\n");
                 return 0;
             }
             else if (args.Length == 2 && args[0] == "description")

--- a/FhirDeathRecord.Tests/fixtures/json/1.json
+++ b/FhirDeathRecord.Tests/fixtures/json/1.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "id": "urn:uuid:3f52e49d-b92d-4c68-bf46-dd10a8ba4fff",
+  "id": "urn:uuid:63eaa04b-f60e-461f-a8bb-b8c558eb2a7b",
   "meta": {
     "profile": [
       "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document"
@@ -12,10 +12,10 @@
   "type": "document",
   "entry": [
     {
-      "fullUrl": "urn:uuid:7e84a26a-6235-4d81-b865-f4463b3821ff",
+      "fullUrl": "urn:uuid:d2fcdfbd-3494-42b4-a140-2827a24a47ae",
       "resource": {
         "resourceType": "Composition",
-        "id": "urn:uuid:7e84a26a-6235-4d81-b865-f4463b3821ff",
+        "id": "urn:uuid:d2fcdfbd-3494-42b4-a140-2827a24a47ae",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate"
@@ -35,7 +35,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "date": "2019-01-20T16:47:04.498822-05:00",
         "attester": [
@@ -45,7 +45,7 @@
             ],
             "time": "2019-01-29T16:48:06.498822-05:00",
             "party": {
-              "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+              "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
             }
           }
         ],
@@ -64,7 +64,7 @@
             ],
             "detail": [
               {
-                "reference": "urn:uuid:db33f83d-206e-4196-95f8-fc5182884c20"
+                "reference": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04"
               }
             ]
           }
@@ -73,100 +73,100 @@
           {
             "entry": [
               {
-                "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+                "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
               },
               {
-                "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+                "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
               },
               {
-                "reference": "urn:uuid:b44c9231-3282-41f9-9a59-d7663a656dc2"
+                "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
               },
               {
-                "reference": "urn:uuid:db33f83d-206e-4196-95f8-fc5182884c20"
+                "reference": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04"
               },
               {
-                "reference": "urn:uuid:33e25be7-cbb2-4994-9780-5fa7a6b2b054"
+                "reference": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244"
               },
               {
-                "reference": "urn:uuid:3d72fc7f-4cb2-4ccc-8119-bc6a1ec91a90"
+                "reference": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313"
               },
               {
-                "reference": "urn:uuid:4b7553ca-b568-4b94-a52a-126636986a48"
+                "reference": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295"
               },
               {
-                "reference": "urn:uuid:c829fdf6-7fff-459d-ba60-bfdbb074d9ca"
+                "reference": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6"
               },
               {
-                "reference": "urn:uuid:5880185b-1f8e-408f-9df9-7ab4b9492995"
+                "reference": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b"
               },
               {
-                "reference": "urn:uuid:dc4f7b2f-3cd9-45f4-a46f-2cf47e5cea83"
+                "reference": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109"
               },
               {
-                "reference": "urn:uuid:ed967388-1416-42b0-926a-52d6f5215e94"
+                "reference": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547"
               },
               {
-                "reference": "urn:uuid:f425b727-a77e-422d-a6f0-6d9bb6fd9cfe"
+                "reference": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2"
               },
               {
-                "reference": "urn:uuid:814fcd50-6065-42a5-8898-7753dece85f0"
+                "reference": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a"
               },
               {
-                "reference": "urn:uuid:d01cf6fd-b36b-4e44-9ba6-a140bf3000e8"
+                "reference": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29"
               },
               {
-                "reference": "urn:uuid:6fcf39d9-4c13-4210-acb7-8bd5e4b3a418"
+                "reference": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65"
               },
               {
-                "reference": "urn:uuid:6d77bdb6-61d2-4e63-afb3-10d27b403287"
+                "reference": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc"
               },
               {
-                "reference": "urn:uuid:02ce7d7f-bfba-4de5-a050-07a214f9371f"
+                "reference": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820"
               },
               {
-                "reference": "urn:uuid:c371bef2-e1af-46df-9901-040a1a4198dd"
+                "reference": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4"
               },
               {
-                "reference": "urn:uuid:7c5e2b73-34e1-49b1-a29e-2905310b64c5"
+                "reference": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932"
               },
               {
-                "reference": "urn:uuid:756d11de-19fb-409b-9fcb-7f11f9a74858"
+                "reference": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201"
               },
               {
-                "reference": "urn:uuid:0a7eb058-6d5d-4fde-8b10-10ec4d9d0092"
+                "reference": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e"
               },
               {
-                "reference": "urn:uuid:61a8b113-be25-4dd6-99b5-cefecd18cae1"
+                "reference": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749"
               },
               {
-                "reference": "urn:uuid:24ed8a4a-d1ea-429d-91ba-42ec9b603cdf"
+                "reference": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895"
               },
               {
-                "reference": "urn:uuid:7324bf29-c1b3-43fd-819f-15b44bbf9af8"
+                "reference": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35"
               },
               {
-                "reference": "urn:uuid:386ed0a8-f25d-4ead-aa0e-f90a7ed14677"
+                "reference": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d"
               },
               {
-                "reference": "urn:uuid:7b8fe475-941b-462b-80f0-b11b2d725ced"
+                "reference": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20"
               },
               {
-                "reference": "urn:uuid:a966f1a8-39ac-43e8-b5b4-0d6289b7b516"
+                "reference": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1"
               },
               {
-                "reference": "urn:uuid:9ff473ea-0b26-441e-9198-bcc8924e9bae"
+                "reference": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2"
               },
               {
-                "reference": "urn:uuid:7114ee7f-4600-47e0-b040-4427b268e58f"
+                "reference": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69"
               },
               {
-                "reference": "urn:uuid:cf3fcd78-0cf4-44a0-b030-2110cc6f5d9d"
+                "reference": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436"
               },
               {
-                "reference": "urn:uuid:35634f90-97f7-4e20-b658-5e7bec7b694c"
+                "reference": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c"
               },
               {
-                "reference": "urn:uuid:fb2e6384-0b29-45f0-b727-f66052db9a73"
+                "reference": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed"
               }
             ]
           }
@@ -174,10 +174,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d",
+      "fullUrl": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8",
       "resource": {
         "resourceType": "Patient",
-        "id": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d",
+        "id": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent"
@@ -324,10 +324,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf",
+      "fullUrl": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf",
+        "id": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier"
@@ -375,10 +375,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:b44c9231-3282-41f9-9a59-d7663a656dc2",
+      "fullUrl": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61",
       "resource": {
         "resourceType": "Practitioner",
-        "id": "urn:uuid:b44c9231-3282-41f9-9a59-d7663a656dc2",
+        "id": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician"
@@ -409,10 +409,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:db33f83d-206e-4196-95f8-fc5182884c20",
+      "fullUrl": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04",
       "resource": {
         "resourceType": "Procedure",
-        "id": "urn:uuid:db33f83d-206e-4196-95f8-fc5182884c20",
+        "id": "urn:uuid:83c00be4-3eb7-455d-80cf-d767d5b7fd04",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification"
@@ -437,7 +437,7 @@
             }
           ]
         },
-        "performedString": "2019-01-29T16:48:06.498822-05:00",
+        "performedDateTime": "2019-01-29T16:48:06.498822-05:00",
         "performer": [
           {
             "role": {
@@ -450,17 +450,17 @@
               ]
             },
             "actor": {
-              "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+              "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
             }
           }
         ]
       }
     },
     {
-      "fullUrl": "urn:uuid:33e25be7-cbb2-4994-9780-5fa7a6b2b054",
+      "fullUrl": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244",
       "resource": {
         "resourceType": "Organization",
-        "id": "urn:uuid:33e25be7-cbb2-4994-9780-5fa7a6b2b054",
+        "id": "urn:uuid:03d104a5-ea62-4087-af82-cf9cc1a12244",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party"
@@ -500,10 +500,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:3d72fc7f-4cb2-4ccc-8119-bc6a1ec91a90",
+      "fullUrl": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313",
       "resource": {
         "resourceType": "Organization",
-        "id": "urn:uuid:3d72fc7f-4cb2-4ccc-8119-bc6a1ec91a90",
+        "id": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home"
@@ -536,28 +536,28 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:4b7553ca-b568-4b94-a52a-126636986a48",
+      "fullUrl": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295",
       "resource": {
         "resourceType": "PractitionerRole",
-        "id": "urn:uuid:4b7553ca-b568-4b94-a52a-126636986a48",
+        "id": "urn:uuid:d0e85418-8d35-4de3-87ee-16737d9d5295",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home-Director"
           ]
         },
         "practitioner": {
-          "reference": "urn:uuid:b44c9231-3282-41f9-9a59-d7663a656dc2"
+          "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
         },
         "organization": {
-          "reference": "urn:uuid:3d72fc7f-4cb2-4ccc-8119-bc6a1ec91a90"
+          "reference": "urn:uuid:adce8a8d-ff16-4b6c-8525-5671d3348313"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:c829fdf6-7fff-459d-ba60-bfdbb074d9ca",
+      "fullUrl": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6",
       "resource": {
         "resourceType": "List",
-        "id": "urn:uuid:c829fdf6-7fff-459d-ba60-bfdbb074d9ca",
+        "id": "urn:uuid:03756adc-5f1c-4e90-b3fd-f965a313dce6",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway"
@@ -566,7 +566,7 @@
         "status": "current",
         "mode": "snapshot",
         "source": {
-          "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         },
         "orderedBy": {
           "coding": [
@@ -578,32 +578,32 @@
         "entry": [
           {
             "item": {
-              "reference": "urn:uuid:f425b727-a77e-422d-a6f0-6d9bb6fd9cfe"
+              "reference": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:814fcd50-6065-42a5-8898-7753dece85f0"
+              "reference": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:d01cf6fd-b36b-4e44-9ba6-a140bf3000e8"
+              "reference": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29"
             }
           },
           {
             "item": {
-              "reference": "urn:uuid:6fcf39d9-4c13-4210-acb7-8bd5e4b3a418"
+              "reference": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65"
             }
           }
         ]
       }
     },
     {
-      "fullUrl": "urn:uuid:5880185b-1f8e-408f-9df9-7ab4b9492995",
+      "fullUrl": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:5880185b-1f8e-408f-9df9-7ab4b9492995",
+        "id": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location"
@@ -624,10 +624,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:dc4f7b2f-3cd9-45f4-a46f-2cf47e5cea83",
+      "fullUrl": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:dc4f7b2f-3cd9-45f4-a46f-2cf47e5cea83",
+        "id": "urn:uuid:bb213c59-3ea4-42b0-85a9-f38f4e7e6109",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death"
@@ -644,11 +644,11 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "performer": [
           {
-            "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+            "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
           }
         ],
         "valueCodeableConcept": {
@@ -662,10 +662,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:ed967388-1416-42b0-926a-52d6f5215e94",
+      "fullUrl": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:ed967388-1416-42b0-926a-52d6f5215e94",
+        "id": "urn:uuid:c8a9fb38-2b6a-4974-83e6-eb5b7f79a547",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death"
@@ -675,15 +675,15 @@
           "text": "Example Contributing Conditions"
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:f425b727-a77e-422d-a6f0-6d9bb6fd9cfe",
+      "fullUrl": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:f425b727-a77e-422d-a6f0-6d9bb6fd9cfe",
+        "id": "urn:uuid:a35f9eee-b4f2-4cfc-9834-553055bbb6c2",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -700,19 +700,19 @@
           "text": "Rupture of myocardium"
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "minutes",
         "asserter": {
-          "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:814fcd50-6065-42a5-8898-7753dece85f0",
+      "fullUrl": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:814fcd50-6065-42a5-8898-7753dece85f0",
+        "id": "urn:uuid:c7b0d5f5-609a-4f89-8f23-cb33d37ae65a",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -729,19 +729,19 @@
           "text": "Acute myocardial infarction"
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "6 days",
         "asserter": {
-          "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:d01cf6fd-b36b-4e44-9ba6-a140bf3000e8",
+      "fullUrl": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:d01cf6fd-b36b-4e44-9ba6-a140bf3000e8",
+        "id": "urn:uuid:c5e23307-e541-49f5-943d-d0a3c82cdd29",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -751,19 +751,19 @@
           "text": "Coronary artery thrombosis"
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "5 years",
         "asserter": {
-          "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:6fcf39d9-4c13-4210-acb7-8bd5e4b3a418",
+      "fullUrl": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65",
       "resource": {
         "resourceType": "Condition",
-        "id": "urn:uuid:6fcf39d9-4c13-4210-acb7-8bd5e4b3a418",
+        "id": "urn:uuid:40b288f1-4c32-4bc9-bce6-396354edfa65",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition"
@@ -773,26 +773,26 @@
           "text": "Atherosclerotic coronary artery disease"
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "onsetString": "7 years",
         "asserter": {
-          "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+          "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
         }
       }
     },
     {
-      "fullUrl": "urn:uuid:6d77bdb6-61d2-4e63-afb3-10d27b403287",
+      "fullUrl": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:6d77bdb6-61d2-4e63-afb3-10d27b403287",
+        "id": "urn:uuid:ae52d16b-14c5-46b1-8100-2353731a6cdc",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -816,17 +816,17 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:02ce7d7f-bfba-4de5-a050-07a214f9371f",
+      "fullUrl": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:02ce7d7f-bfba-4de5-a050-07a214f9371f",
+        "id": "urn:uuid:17e06964-e4bc-4909-a956-afad4e0b7820",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -850,17 +850,17 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:c371bef2-e1af-46df-9901-040a1a4198dd",
+      "fullUrl": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "urn:uuid:c371bef2-e1af-46df-9901-040a1a4198dd",
+        "id": "urn:uuid:5b929ad0-1626-4b2b-88b9-ccfbd94a74b4",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse"
           ]
         },
         "patient": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "relationship": {
           "coding": [
@@ -884,10 +884,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:7c5e2b73-34e1-49b1-a29e-2905310b64c5",
+      "fullUrl": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:7c5e2b73-34e1-49b1-a29e-2905310b64c5",
+        "id": "urn:uuid:6eebaaa7-2408-4664-b63d-b3083e97d932",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level"
@@ -904,7 +904,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -918,10 +918,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:756d11de-19fb-409b-9fcb-7f11f9a74858",
+      "fullUrl": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:756d11de-19fb-409b-9fcb-7f11f9a74858",
+        "id": "urn:uuid:a0590dab-cb92-4b05-ab57-4d7fc28b8201",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Birth-Record-Identifier"
@@ -936,16 +936,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueString": "4242123"
       }
     },
     {
-      "fullUrl": "urn:uuid:0a7eb058-6d5d-4fde-8b10-10ec4d9d0092",
+      "fullUrl": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:0a7eb058-6d5d-4fde-8b10-10ec4d9d0092",
+        "id": "urn:uuid:f2bc2de8-cb7d-40b7-b77b-0537da711d0e",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Employment-History"
@@ -962,7 +962,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "component": [
           {
@@ -1029,10 +1029,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:61a8b113-be25-4dd6-99b5-cefecd18cae1",
+      "fullUrl": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:61a8b113-be25-4dd6-99b5-cefecd18cae1",
+        "id": "urn:uuid:d9b487d8-21de-4085-b9e9-4b9376dda749",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method"
@@ -1042,7 +1042,7 @@
           {
             "url": "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location",
             "valueReference": {
-              "reference": "urn:uuid:5880185b-1f8e-408f-9df9-7ab4b9492995"
+              "reference": "urn:uuid:4f565c50-ae62-44af-be31-59eb5d6c531b"
             }
           }
         ],
@@ -1057,11 +1057,11 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "performer": [
           {
-            "reference": "urn:uuid:b44c9231-3282-41f9-9a59-d7663a656dc2"
+            "reference": "urn:uuid:c97cef68-178c-4636-8f83-2bd1bc988b61"
           }
         ],
         "valueCodeableConcept": {
@@ -1076,10 +1076,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:24ed8a4a-d1ea-429d-91ba-42ec9b603cdf",
+      "fullUrl": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:24ed8a4a-d1ea-429d-91ba-42ec9b603cdf",
+        "id": "urn:uuid:8a85dab4-0743-439e-bacf-5fdd34122895",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator"
@@ -1096,7 +1096,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1132,10 +1132,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:7324bf29-c1b3-43fd-819f-15b44bbf9af8",
+      "fullUrl": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:7324bf29-c1b3-43fd-819f-15b44bbf9af8",
+        "id": "urn:uuid:24f3cb0a-d833-4d11-aacc-039f6e3a7c35",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age"
@@ -1152,7 +1152,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueQuantity": {
           "value": 100,
@@ -1161,10 +1161,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:386ed0a8-f25d-4ead-aa0e-f90a7ed14677",
+      "fullUrl": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:386ed0a8-f25d-4ead-aa0e-f90a7ed14677",
+        "id": "urn:uuid:3490104b-b1e2-44bc-bfb8-ffb74097df6d",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy"
@@ -1181,7 +1181,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1195,10 +1195,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:7b8fe475-941b-462b-80f0-b11b2d725ced",
+      "fullUrl": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:7b8fe475-941b-462b-80f0-b11b2d725ced",
+        "id": "urn:uuid:d111817b-b8f3-4b18-80e0-2fb6bcc52e20",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role"
@@ -1215,7 +1215,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1229,10 +1229,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:a966f1a8-39ac-43e8-b5b4-0d6289b7b516",
+      "fullUrl": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:a966f1a8-39ac-43e8-b5b4-0d6289b7b516",
+        "id": "urn:uuid:9be3384d-7b87-4d8d-92b1-9b1f12976fa1",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted"
@@ -1249,16 +1249,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueBoolean": false
       }
     },
     {
-      "fullUrl": "urn:uuid:9ff473ea-0b26-441e-9198-bcc8924e9bae",
+      "fullUrl": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:9ff473ea-0b26-441e-9198-bcc8924e9bae",
+        "id": "urn:uuid:60687ff4-5fe5-4e4d-b6cd-2d2015adf0a2",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death"
@@ -1275,7 +1275,7 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "valueCodeableConcept": {
           "coding": [
@@ -1289,10 +1289,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:7114ee7f-4600-47e0-b040-4427b268e58f",
+      "fullUrl": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:7114ee7f-4600-47e0-b040-4427b268e58f",
+        "id": "urn:uuid:0d73f473-d4fd-480d-a736-4b3443b40b69",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location"
@@ -1314,10 +1314,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:cf3fcd78-0cf4-44a0-b030-2110cc6f5d9d",
+      "fullUrl": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:cf3fcd78-0cf4-44a0-b030-2110cc6f5d9d",
+        "id": "urn:uuid:785d0e7e-a582-4f0f-96ac-da1d317ad436",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Incident"
@@ -1334,16 +1334,16 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "effectiveDateTime": "2018-02-19T16:48:06.498822-05:00"
       }
     },
     {
-      "fullUrl": "urn:uuid:35634f90-97f7-4e20-b658-5e7bec7b694c",
+      "fullUrl": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c",
       "resource": {
         "resourceType": "Location",
-        "id": "urn:uuid:35634f90-97f7-4e20-b658-5e7bec7b694c",
+        "id": "urn:uuid:2f09577e-a7a3-46a1-ad14-dc66efe8f03c",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location"
@@ -1365,10 +1365,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:fb2e6384-0b29-45f0-b727-f66052db9a73",
+      "fullUrl": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed",
       "resource": {
         "resourceType": "Observation",
-        "id": "urn:uuid:fb2e6384-0b29-45f0-b727-f66052db9a73",
+        "id": "urn:uuid:7fd1dd23-5c61-4d31-8180-3d5715e280ed",
         "meta": {
           "profile": [
             "http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date"
@@ -1385,12 +1385,12 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:5c77bf6f-9145-40c4-a4ce-7f3b7af6080d"
+          "reference": "urn:uuid:52ddf5c3-bd68-4d02-8c67-c004aad833a8"
         },
         "effectiveDateTime": "2018-02-19T16:48:06.498822-05:00",
         "performer": [
           {
-            "reference": "urn:uuid:edfe4ecf-f225-4b56-be07-3197a7da84bf"
+            "reference": "urn:uuid:01f8a847-96c6-44ce-8f30-278d9a1b755f"
           }
         ],
         "component": [

--- a/FhirDeathRecord.Tests/fixtures/xml/1.xml
+++ b/FhirDeathRecord.Tests/fixtures/xml/1.xml
@@ -1,5 +1,5 @@
 <Bundle xmlns="http://hl7.org/fhir">
-  <id value="urn:uuid:df4f603d-f20e-4a95-8536-613dec8ad5a2" />
+  <id value="urn:uuid:1f85404c-19bf-413e-b975-d87f1a48ab08" />
   <meta>
     <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate-Document" />
   </meta>
@@ -8,10 +8,10 @@
   </identifier>
   <type value="document" />
   <entry>
-    <fullUrl value="urn:uuid:ea957498-3757-490c-9b07-f29dab80819e" />
+    <fullUrl value="urn:uuid:792f37f0-9a17-4016-9a51-ca6899d5bc1d" />
     <resource>
       <Composition>
-        <id value="urn:uuid:ea957498-3757-490c-9b07-f29dab80819e" />
+        <id value="urn:uuid:792f37f0-9a17-4016-9a51-ca6899d5bc1d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certificate" />
         </meta>
@@ -27,14 +27,14 @@
           </coding>
         </type>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <date value="2019-01-20T16:47:04.4988220-05:00" />
         <attester>
           <mode value="legal" />
           <time value="2019-01-29T16:48:06.4988220-05:00" />
           <party>
-            <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </party>
         </attester>
         <event>
@@ -46,115 +46,115 @@
             </coding>
           </code>
           <detail>
-            <reference value="urn:uuid:8d5eb2ae-5dfa-4e60-a4b9-68228d55ab9d" />
+            <reference value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
           </detail>
         </event>
         <section>
           <entry>
-            <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+            <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
           </entry>
           <entry>
-            <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </entry>
           <entry>
-            <reference value="urn:uuid:a0f9f11d-bd67-455d-8a91-5e321a98fc23" />
+            <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:8d5eb2ae-5dfa-4e60-a4b9-68228d55ab9d" />
+            <reference value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
           </entry>
           <entry>
-            <reference value="urn:uuid:112aa7d9-4f98-448f-9a3d-1259b5dcae2b" />
+            <reference value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
           </entry>
           <entry>
-            <reference value="urn:uuid:2843b3bf-3141-4179-808b-5da1ca5ac31a" />
+            <reference value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
           </entry>
           <entry>
-            <reference value="urn:uuid:0365a672-853b-46b4-9874-3918c2b9e9d6" />
+            <reference value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
           </entry>
           <entry>
-            <reference value="urn:uuid:d12bc4d1-16bd-43e8-8696-c68a1fa810df" />
+            <reference value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
           </entry>
           <entry>
-            <reference value="urn:uuid:959ad93e-635e-4e8f-8c8e-73dc91a0784b" />
+            <reference value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
           </entry>
           <entry>
-            <reference value="urn:uuid:7037eb7f-fea2-46cd-b371-aa6efb836719" />
+            <reference value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
           </entry>
           <entry>
-            <reference value="urn:uuid:081734ba-6e89-45bc-a719-efdea87f8297" />
+            <reference value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
           </entry>
           <entry>
-            <reference value="urn:uuid:7d53312d-a36a-4b82-9dc9-a7e93398a127" />
+            <reference value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
           </entry>
           <entry>
-            <reference value="urn:uuid:4646e0a1-bd9a-4061-b5df-46db7d4d5ec7" />
+            <reference value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
           </entry>
           <entry>
-            <reference value="urn:uuid:a7061cca-dfa6-4c1d-a76a-bf71d7b78416" />
+            <reference value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
           </entry>
           <entry>
-            <reference value="urn:uuid:5d1d8df1-5314-4c61-8bee-08fe4d088591" />
+            <reference value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
           </entry>
           <entry>
-            <reference value="urn:uuid:35e733b5-8e8e-472d-ae5b-8e67602446ee" />
+            <reference value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
           </entry>
           <entry>
-            <reference value="urn:uuid:9d7cd981-fd83-471d-88fb-d1b3b4d9c1de" />
+            <reference value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
           </entry>
           <entry>
-            <reference value="urn:uuid:b354a96d-ecec-4664-af47-a32255faef0e" />
+            <reference value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
           </entry>
           <entry>
-            <reference value="urn:uuid:e4b7946b-9f01-4a89-a0ac-8a0659e4ddb3" />
+            <reference value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
           </entry>
           <entry>
-            <reference value="urn:uuid:c7789632-1b4b-43f1-abfc-1bb40d9e09e8" />
+            <reference value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:93edc322-f61e-4da4-aa65-fa034ed04f55" />
+            <reference value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
           </entry>
           <entry>
-            <reference value="urn:uuid:2504d90f-9d32-4116-b40b-b689fd85925c" />
+            <reference value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
           </entry>
           <entry>
-            <reference value="urn:uuid:7d163119-b654-4600-b3df-ab67af0bd308" />
+            <reference value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
           </entry>
           <entry>
-            <reference value="urn:uuid:250149b8-ee5f-4c83-9ebb-676a8c518fcf" />
+            <reference value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:c6aba9b5-6a1a-4783-8c22-8d3521139ad1" />
+            <reference value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
           </entry>
           <entry>
-            <reference value="urn:uuid:8321264a-7386-44e7-a01b-55ccf2e1ff62" />
+            <reference value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
           </entry>
           <entry>
-            <reference value="urn:uuid:c6463af8-1a67-41d6-9adc-ad3ce54c71a8" />
+            <reference value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
           </entry>
           <entry>
-            <reference value="urn:uuid:bdacc4e9-58cf-4b1d-abae-fafa3c06824a" />
+            <reference value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
           </entry>
           <entry>
-            <reference value="urn:uuid:57f90695-95c5-4753-8276-878818d4426c" />
+            <reference value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
           </entry>
           <entry>
-            <reference value="urn:uuid:26ca48ab-5caf-4b9c-9f38-84e7eedc6e2e" />
+            <reference value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
           </entry>
           <entry>
-            <reference value="urn:uuid:f93267c7-c137-481a-9ae5-c8fea2216261" />
+            <reference value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
           </entry>
           <entry>
-            <reference value="urn:uuid:a67389ba-d69f-4a76-b565-ad450f1c85fc" />
+            <reference value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
           </entry>
         </section>
       </Composition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+    <fullUrl value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
     <resource>
       <Patient>
-        <id value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+        <id value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent" />
         </meta>
@@ -262,10 +262,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+    <fullUrl value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
     <resource>
       <Practitioner>
-        <id value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+        <id value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Certifier" />
         </meta>
@@ -298,10 +298,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:a0f9f11d-bd67-455d-8a91-5e321a98fc23" />
+    <fullUrl value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
     <resource>
       <Practitioner>
-        <id value="urn:uuid:a0f9f11d-bd67-455d-8a91-5e321a98fc23" />
+        <id value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Mortician" />
         </meta>
@@ -321,10 +321,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:8d5eb2ae-5dfa-4e60-a4b9-68228d55ab9d" />
+    <fullUrl value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
     <resource>
       <Procedure>
-        <id value="urn:uuid:8d5eb2ae-5dfa-4e60-a4b9-68228d55ab9d" />
+        <id value="urn:uuid:c899a534-edca-4a93-b949-f64e13a5ab2c" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Certification" />
         </meta>
@@ -343,7 +343,7 @@
             <display value="Death certification" />
           </coding>
         </code>
-        <performedString value="2019-01-29T16:48:06.4988220-05:00" />
+        <performedDateTime value="2019-01-29T16:48:06.4988220-05:00" />
         <performer>
           <role>
             <coding>
@@ -353,17 +353,17 @@
             </coding>
           </role>
           <actor>
-            <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+            <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
           </actor>
         </performer>
       </Procedure>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:112aa7d9-4f98-448f-9a3d-1259b5dcae2b" />
+    <fullUrl value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
     <resource>
       <Organization>
-        <id value="urn:uuid:112aa7d9-4f98-448f-9a3d-1259b5dcae2b" />
+        <id value="urn:uuid:84258d91-ff19-4d69-afd9-1b10575dad51" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Interested-Party" />
         </meta>
@@ -392,10 +392,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:2843b3bf-3141-4179-808b-5da1ca5ac31a" />
+    <fullUrl value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
     <resource>
       <Organization>
-        <id value="urn:uuid:2843b3bf-3141-4179-808b-5da1ca5ac31a" />
+        <id value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home" />
         </meta>
@@ -419,34 +419,34 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:0365a672-853b-46b4-9874-3918c2b9e9d6" />
+    <fullUrl value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
     <resource>
       <PractitionerRole>
-        <id value="urn:uuid:0365a672-853b-46b4-9874-3918c2b9e9d6" />
+        <id value="urn:uuid:6bfa0cbc-4025-44ca-917f-3524a32cab52" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Funeral-Home-Director" />
         </meta>
         <practitioner>
-          <reference value="urn:uuid:a0f9f11d-bd67-455d-8a91-5e321a98fc23" />
+          <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         </practitioner>
         <organization>
-          <reference value="urn:uuid:2843b3bf-3141-4179-808b-5da1ca5ac31a" />
+          <reference value="urn:uuid:8a03a15d-b15a-45e2-b1de-3d10c0920c4b" />
         </organization>
       </PractitionerRole>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:d12bc4d1-16bd-43e8-8696-c68a1fa810df" />
+    <fullUrl value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
     <resource>
       <List>
-        <id value="urn:uuid:d12bc4d1-16bd-43e8-8696-c68a1fa810df" />
+        <id value="urn:uuid:7ed29ca0-2759-4b66-acb9-a8376a446a71" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-of-Death-Pathway" />
         </meta>
         <status value="current" />
         <mode value="snapshot" />
         <source>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </source>
         <orderedBy>
           <coding>
@@ -455,32 +455,32 @@
         </orderedBy>
         <entry>
           <item>
-            <reference value="urn:uuid:7d53312d-a36a-4b82-9dc9-a7e93398a127" />
+            <reference value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:4646e0a1-bd9a-4061-b5df-46db7d4d5ec7" />
+            <reference value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:a7061cca-dfa6-4c1d-a76a-bf71d7b78416" />
+            <reference value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
           </item>
         </entry>
         <entry>
           <item>
-            <reference value="urn:uuid:5d1d8df1-5314-4c61-8bee-08fe4d088591" />
+            <reference value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
           </item>
         </entry>
       </List>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:959ad93e-635e-4e8f-8c8e-73dc91a0784b" />
+    <fullUrl value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
     <resource>
       <Location>
-        <id value="urn:uuid:959ad93e-635e-4e8f-8c8e-73dc91a0784b" />
+        <id value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location" />
         </meta>
@@ -498,10 +498,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:7037eb7f-fea2-46cd-b371-aa6efb836719" />
+    <fullUrl value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
     <resource>
       <Observation>
-        <id value="urn:uuid:7037eb7f-fea2-46cd-b371-aa6efb836719" />
+        <id value="urn:uuid:32e37318-4287-4b5a-97ac-0a9782c57da5" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Manner-of-Death" />
         </meta>
@@ -514,10 +514,10 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <performer>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </performer>
         <valueCodeableConcept>
           <coding>
@@ -529,10 +529,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:081734ba-6e89-45bc-a719-efdea87f8297" />
+    <fullUrl value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
     <resource>
       <Condition>
-        <id value="urn:uuid:081734ba-6e89-45bc-a719-efdea87f8297" />
+        <id value="urn:uuid:3dc2ca6e-bc67-4459-af9d-db42311c661e" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Condition-Contributing-To-Death" />
         </meta>
@@ -540,16 +540,16 @@
           <text value="Example Contributing Conditions" />
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:7d53312d-a36a-4b82-9dc9-a7e93398a127" />
+    <fullUrl value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
     <resource>
       <Condition>
-        <id value="urn:uuid:7d53312d-a36a-4b82-9dc9-a7e93398a127" />
+        <id value="urn:uuid:15b754ee-2ce9-46b7-85a9-14550118ca0e" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -562,20 +562,20 @@
           <text value="Rupture of myocardium" />
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="minutes" />
         <asserter>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:4646e0a1-bd9a-4061-b5df-46db7d4d5ec7" />
+    <fullUrl value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
     <resource>
       <Condition>
-        <id value="urn:uuid:4646e0a1-bd9a-4061-b5df-46db7d4d5ec7" />
+        <id value="urn:uuid:084c7b44-196b-4d17-8ebe-3e1c68ca844a" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -588,20 +588,20 @@
           <text value="Acute myocardial infarction" />
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="6 days" />
         <asserter>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:a7061cca-dfa6-4c1d-a76a-bf71d7b78416" />
+    <fullUrl value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
     <resource>
       <Condition>
-        <id value="urn:uuid:a7061cca-dfa6-4c1d-a76a-bf71d7b78416" />
+        <id value="urn:uuid:b34b6db6-0323-4668-84e8-10a0b40ade77" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -609,20 +609,20 @@
           <text value="Coronary artery thrombosis" />
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="5 years" />
         <asserter>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:5d1d8df1-5314-4c61-8bee-08fe4d088591" />
+    <fullUrl value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
     <resource>
       <Condition>
-        <id value="urn:uuid:5d1d8df1-5314-4c61-8bee-08fe4d088591" />
+        <id value="urn:uuid:1eae9c9b-51e3-4e67-94de-c31cca8b29f6" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Cause-Of-Death-Condition" />
         </meta>
@@ -630,25 +630,25 @@
           <text value="Atherosclerotic coronary artery disease" />
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <onsetString value="7 years" />
         <asserter>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </asserter>
       </Condition>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:35e733b5-8e8e-472d-ae5b-8e67602446ee" />
+    <fullUrl value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:35e733b5-8e8e-472d-ae5b-8e67602446ee" />
+        <id value="urn:uuid:af59654f-faea-41d8-bdca-3b98cb798bdc" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Father" />
         </meta>
         <patient>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -665,15 +665,15 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:9d7cd981-fd83-471d-88fb-d1b3b4d9c1de" />
+    <fullUrl value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:9d7cd981-fd83-471d-88fb-d1b3b4d9c1de" />
+        <id value="urn:uuid:492e1351-4e80-46ca-85a7-d8bdabf9b38c" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Mother" />
         </meta>
         <patient>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -690,15 +690,15 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:b354a96d-ecec-4664-af47-a32255faef0e" />
+    <fullUrl value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
     <resource>
       <RelatedPerson>
-        <id value="urn:uuid:b354a96d-ecec-4664-af47-a32255faef0e" />
+        <id value="urn:uuid:afaeeb96-7989-41a3-bbc6-c600da5c22ab" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Spouse" />
         </meta>
         <patient>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </patient>
         <relationship>
           <coding>
@@ -715,10 +715,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:e4b7946b-9f01-4a89-a0ac-8a0659e4ddb3" />
+    <fullUrl value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
     <resource>
       <Observation>
-        <id value="urn:uuid:e4b7946b-9f01-4a89-a0ac-8a0659e4ddb3" />
+        <id value="urn:uuid:a8206784-59e6-4844-ac86-5736a610bc84" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Education-Level" />
         </meta>
@@ -731,7 +731,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -744,10 +744,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:c7789632-1b4b-43f1-abfc-1bb40d9e09e8" />
+    <fullUrl value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:c7789632-1b4b-43f1-abfc-1bb40d9e09e8" />
+        <id value="urn:uuid:94efacc7-6101-4df1-8e8f-cdee7743b4a8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Birth-Record-Identifier" />
         </meta>
@@ -758,17 +758,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueString value="4242123" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:93edc322-f61e-4da4-aa65-fa034ed04f55" />
+    <fullUrl value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
     <resource>
       <Observation>
-        <id value="urn:uuid:93edc322-f61e-4da4-aa65-fa034ed04f55" />
+        <id value="urn:uuid:8eea7ce9-906d-4765-838b-a159ee49a505" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Employment-History" />
         </meta>
@@ -781,7 +781,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <component>
           <code>
@@ -835,16 +835,16 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:2504d90f-9d32-4116-b40b-b689fd85925c" />
+    <fullUrl value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
     <resource>
       <Observation>
-        <id value="urn:uuid:2504d90f-9d32-4116-b40b-b689fd85925c" />
+        <id value="urn:uuid:267cd537-4d4b-41e1-8a69-3aa9fb6b5432" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Disposition-Method" />
         </meta>
         <extension url="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Disposition-Location">
           <valueReference>
-            <reference value="urn:uuid:959ad93e-635e-4e8f-8c8e-73dc91a0784b" />
+            <reference value="urn:uuid:faea422a-1360-4e9a-8327-252ebb9bc94f" />
           </valueReference>
         </extension>
         <status value="final" />
@@ -856,10 +856,10 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <performer>
-          <reference value="urn:uuid:a0f9f11d-bd67-455d-8a91-5e321a98fc23" />
+          <reference value="urn:uuid:c474c232-4e0c-409a-9a23-eb682ee39aa8" />
         </performer>
         <valueCodeableConcept>
           <coding>
@@ -872,10 +872,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:7d163119-b654-4600-b3df-ab67af0bd308" />
+    <fullUrl value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
     <resource>
       <Observation>
-        <id value="urn:uuid:7d163119-b654-4600-b3df-ab67af0bd308" />
+        <id value="urn:uuid:8f6122e9-f151-4f7a-9300-c1ba9e286116" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Autopsy-Performed-Indicator" />
         </meta>
@@ -888,7 +888,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -917,10 +917,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:250149b8-ee5f-4c83-9ebb-676a8c518fcf" />
+    <fullUrl value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:250149b8-ee5f-4c83-9ebb-676a8c518fcf" />
+        <id value="urn:uuid:0f2142fc-56f4-493b-be72-7a05853533a8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Age" />
         </meta>
@@ -933,7 +933,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueQuantity>
           <value value="100" />
@@ -943,10 +943,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:c6aba9b5-6a1a-4783-8c22-8d3521139ad1" />
+    <fullUrl value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
     <resource>
       <Observation>
-        <id value="urn:uuid:c6aba9b5-6a1a-4783-8c22-8d3521139ad1" />
+        <id value="urn:uuid:dc2407c9-4520-48b9-ac2e-7679338971a5" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Pregnancy" />
         </meta>
@@ -959,7 +959,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -972,10 +972,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:8321264a-7386-44e7-a01b-55ccf2e1ff62" />
+    <fullUrl value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
     <resource>
       <Observation>
-        <id value="urn:uuid:8321264a-7386-44e7-a01b-55ccf2e1ff62" />
+        <id value="urn:uuid:e6a669b3-0b40-47ea-a572-15d12e106af7" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Decedent-Transportation-Role" />
         </meta>
@@ -988,7 +988,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -1001,10 +1001,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:c6463af8-1a67-41d6-9adc-ad3ce54c71a8" />
+    <fullUrl value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
     <resource>
       <Observation>
-        <id value="urn:uuid:c6463af8-1a67-41d6-9adc-ad3ce54c71a8" />
+        <id value="urn:uuid:e07d5547-d6a3-4141-af05-50030fe270bd" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Examiner-Contacted" />
         </meta>
@@ -1017,17 +1017,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueBoolean value="false" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:bdacc4e9-58cf-4b1d-abae-fafa3c06824a" />
+    <fullUrl value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
     <resource>
       <Observation>
-        <id value="urn:uuid:bdacc4e9-58cf-4b1d-abae-fafa3c06824a" />
+        <id value="urn:uuid:2811b16b-cd3f-4fd2-8736-ab1709adaf9b" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Tobacco-Use-Contributed-To-Death" />
         </meta>
@@ -1040,7 +1040,7 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <valueCodeableConcept>
           <coding>
@@ -1053,10 +1053,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:57f90695-95c5-4753-8276-878818d4426c" />
+    <fullUrl value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
     <resource>
       <Location>
-        <id value="urn:uuid:57f90695-95c5-4753-8276-878818d4426c" />
+        <id value="urn:uuid:6a6102e7-e472-41e2-8c02-2b91690687c7" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Location" />
         </meta>
@@ -1075,10 +1075,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:26ca48ab-5caf-4b9c-9f38-84e7eedc6e2e" />
+    <fullUrl value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
     <resource>
       <Observation>
-        <id value="urn:uuid:26ca48ab-5caf-4b9c-9f38-84e7eedc6e2e" />
+        <id value="urn:uuid:6b116872-7869-4612-9eee-2e7680b56ec8" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Injury-Incident" />
         </meta>
@@ -1091,17 +1091,17 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <effectiveDateTime value="2018-02-19T16:48:06.4988220-05:00" />
       </Observation>
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:f93267c7-c137-481a-9ae5-c8fea2216261" />
+    <fullUrl value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
     <resource>
       <Location>
-        <id value="urn:uuid:f93267c7-c137-481a-9ae5-c8fea2216261" />
+        <id value="urn:uuid:21b8631b-c791-4ab6-8f02-ce5a44fe2e8d" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Location" />
         </meta>
@@ -1120,10 +1120,10 @@
     </resource>
   </entry>
   <entry>
-    <fullUrl value="urn:uuid:a67389ba-d69f-4a76-b565-ad450f1c85fc" />
+    <fullUrl value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
     <resource>
       <Observation>
-        <id value="urn:uuid:a67389ba-d69f-4a76-b565-ad450f1c85fc" />
+        <id value="urn:uuid:f1c734a2-33f3-494a-b8d3-3e76668c6fe1" />
         <meta>
           <profile value="http://www.hl7.org/fhir/us/vrdr/StructureDefinition/VRDR-Death-Date" />
         </meta>
@@ -1136,11 +1136,11 @@
           </coding>
         </code>
         <subject>
-          <reference value="urn:uuid:19c0d941-453a-47ad-b1b7-53b8a438872c" />
+          <reference value="urn:uuid:e873e284-eff0-4435-b125-bef990b7d871" />
         </subject>
         <effectiveDateTime value="2018-02-19T16:48:06.4988220-05:00" />
         <performer>
-          <reference value="urn:uuid:e50531d6-c0bf-4c3b-a0ce-e1687c3ae612" />
+          <reference value="urn:uuid:ffa0d2cb-cd42-4542-b814-35b1a09a9c4d" />
         </performer>
         <component>
           <code>

--- a/FhirDeathRecord/DeathRecord.cs
+++ b/FhirDeathRecord/DeathRecord.cs
@@ -423,12 +423,12 @@ namespace FhirDeathRecord
                     AddReferenceToComposition(DeathCertification.Id);
                     Bundle.AddResourceEntry(DeathCertification, DeathCertification.Id);
                     Composition.Attester.First().Time = value;
-                    DeathCertification.Performed = new FhirString(value);
+                    DeathCertification.Performed = new FhirDateTime(value);
                 }
                 else
                 {
                     Composition.Attester.First().Time = value;
-                    DeathCertification.Performed = new FhirString(value);
+                    DeathCertification.Performed = new FhirDateTime(value);
                 }
             }
         }

--- a/FhirDeathRecord/DeathRecord.csproj
+++ b/FhirDeathRecord/DeathRecord.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>FhirDeathRecord</RootNamespace>
     <DocumentationFile>DeathRecord.xml</DocumentationFile>
     <PackageId>FHIRDeathRecord</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <ProjectUrl>https://github.com/nightingaleproject/csharp-fhir-death-record</ProjectUrl>
     <RepositoryUrl>https://github.com/nightingaleproject/csharp-fhir-death-record</RepositoryUrl>
     <Title>FHIR Death Record</Title>

--- a/FhirDeathRecord/DeathRecord.csproj
+++ b/FhirDeathRecord/DeathRecord.csproj
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.1.2" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="1.2.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using performedDateTime instead of performedString in procedure, as performedString was only introduced in R4.

Updated C# FHIR Library dependency to 1.2.1.